### PR TITLE
Update layout to show more info in one page

### DIFF
--- a/frontend/src/presentation/MovieList/index.js
+++ b/frontend/src/presentation/MovieList/index.js
@@ -49,12 +49,12 @@ class MovieList extends Component {
       actorsArray = actors.map((actor) => { return actor.value });
     }
 
-    // Not showing more than 5 actors at a time
-    if (actorsArray.length > 5) {
-      const remainingCount = actorsArray.length - 5;
+    // Not showing more than 4 actors at a time
+    if (actorsArray.length > 4) {
+      const remainingCount = actorsArray.length - 4;
       remainingPostfix = ' and ' + remainingCount;
       remainingPostfix += remainingCount > 1 ? ' others' : ' other';
-      actorsArray = actorsArray.slice(0, 5);
+      actorsArray = actorsArray.slice(0, 4);
     }
 
     actorsHtml = actorsArray.join(', ') + remainingPostfix;
@@ -101,7 +101,7 @@ class MovieList extends Component {
     });
 
     return (
-      <div className="movie-list">
+      <div className="movie-list column is-half">
         <article className="media">
 
           <div className="media-left">

--- a/frontend/src/presentation/MovieList/style.scss
+++ b/frontend/src/presentation/MovieList/style.scss
@@ -4,17 +4,20 @@
 .movie-list {
   padding: 0.75rem;
   box-shadow: none;
+  border-bottom: solid 1px $border-colour;
 
   @include mobile {
-    margin: 0 -0.75rem;
+    margin: 0 -0.5rem;
   }
 
   &:hover {
     background-color: $hover-background-colour;
   }
 
-  &:not(:last-of-type) {
-    border-bottom: solid 1px $border-colour;
+  .media {
+    .media-left {
+      margin-right: 0.75rem;
+    }
   }
 
   .image {
@@ -41,6 +44,20 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+
+    > div:first-of-type {
+      max-width: 85%;
+    }
+
+    .movie-info {
+      font-size: 0.95rem;
+      line-height: 1.0rem;
+      padding-top: 0.5rem;
+    }
+
+    .movie-cast {
+      line-height: 1.3rem;
+    }
   }
 
   .title.movie-title {

--- a/frontend/src/presentation/Search/Box/style.scss
+++ b/frontend/src/presentation/Search/Box/style.scss
@@ -4,7 +4,7 @@
 .search-box-field {
 
   @include from($tablet) {
-    padding: 0 0.75rem;
+    padding-left: 0.75rem;
   }
 
   .control {

--- a/frontend/src/presentation/Search/Results/index.js
+++ b/frontend/src/presentation/Search/Results/index.js
@@ -28,7 +28,7 @@ class SearchResults extends Component {
           <div className="search-results-counters">
             {this.props.showCounters && this.getCounters()}
           </div>
-          <div className="search-results-movie-list">
+          <div className="search-results-movie-list columns is-multiline">
             {this.props.children}
           </div>
         </div>

--- a/frontend/src/presentation/Search/Results/style.scss
+++ b/frontend/src/presentation/Search/Results/style.scss
@@ -6,7 +6,13 @@
     margin-bottom: 0.75rem;
 
     @include from($tablet) {
-      padding: 0 0.75rem;
+      padding-left: 0.75rem;
+    }
+  }
+
+  .search-results-movie-list.columns {
+    @include from($tablet) {
+      padding-left: 0.75rem;
     }
   }
 }

--- a/frontend/src/presentation/TwoColumnLayout/style.scss
+++ b/frontend/src/presentation/TwoColumnLayout/style.scss
@@ -4,9 +4,9 @@
 .section.two-column-layout {
   padding-bottom: 0;
 
-  .container {
+  > .container {
 
-    .columns {
+    > .columns {
       padding: 1.25rem;
       background-color: #FFFFFF;
       border-radius: 6px;
@@ -15,7 +15,7 @@
       transform: translateY(-70px);
       align-items: flex-start;
 
-      .column {
+      > .column {
         padding-top: 0;
         margin-top: 0.75rem;
 


### PR DESCRIPTION
To show more information in one page, we can either reduce the size of each movie row, or make it a 2 column layout. This PR implements the former.

### Before
![screen shot 2018-08-09 at 12 22 01 pm](https://user-images.githubusercontent.com/2060518/43883301-4137212e-9bd0-11e8-9ac0-ff01c8dfe749.png)

### After
![screen shot 2018-08-09 at 12 21 43 pm](https://user-images.githubusercontent.com/2060518/43883315-535ff81c-9bd0-11e8-8d5e-36b789fbc85e.png)
